### PR TITLE
Use Git URL for sim-api-wrapper dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ readme = "README.md"
 license = { text = "MIT" }
 requires-python = ">=3.10"
 dependencies = [
-    "sim-api-wrapper",
+    "sim-api-wrapper @ git+https://github.com/m-a-r-o-u/sim-api-wrapper.git",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
## Summary
- update the sim-api-wrapper dependency to pull directly from the GitHub repository

## Testing
- uv pip install -e . *(fails: No virtual environment found; run `uv venv` to create an environment, or pass `--system`)*

------
https://chatgpt.com/codex/tasks/task_e_68d99fac776083259a9bad22fd824870