### PR TITLE
Allow direct references for git dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,9 @@ dev = [
 requires = ["hatchling"]
 build-backend = "hatchling.build"
 
+[tool.hatch.metadata]
+allow-direct-references = true
+
 [tool.black]
 line-length = 88
 target-version = ["py310"]


### PR DESCRIPTION
## Summary
- enable Hatch metadata option to allow direct references so the git dependency builds successfully

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d9a04ebd7c8325910d11e0922dffb6