### PR TITLE
Integrate SimApiClient context manager

### DIFF
--- a/src/sim_apps/cli.py
+++ b/src/sim_apps/cli.py
@@ -81,21 +81,21 @@ def _build_group_filters(args: argparse.Namespace) -> Sequence:
 
 
 def run_email_list(args: argparse.Namespace) -> int:
-    client = SIMClientAdapter.from_default()
-    pipeline = EmailListPipeline(
-        client=client,
-        service=args.service,
-        group_filters=_build_group_filters(args),
-        dedup_strategy=args.dedup,
-        institution=args.institution,
-        domain_hint=args.domain_hint,
-        output_path=args.output,
-        csv_path=args.csv,
-        emit_stdout=args.stdout,
-        debug_dir=args.debug_intermediate,
-        logger=logging.getLogger("sim_apps.email_list"),
-    )
-    context = pipeline.run(dry_run=args.dry_run)
+    with SIMClientAdapter.from_default() as client:
+        pipeline = EmailListPipeline(
+            client=client,
+            service=args.service,
+            group_filters=_build_group_filters(args),
+            dedup_strategy=args.dedup,
+            institution=args.institution,
+            domain_hint=args.domain_hint,
+            output_path=args.output,
+            csv_path=args.csv,
+            emit_stdout=args.stdout,
+            debug_dir=args.debug_intermediate,
+            logger=logging.getLogger("sim_apps.email_list"),
+        )
+        context = pipeline.run(dry_run=args.dry_run)
     preview = context.get("preview")
     if preview:
         print("Dry run preview:" if args.dry_run else "Result summary:")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -18,6 +18,9 @@ class FakeSimClient:
             ]
         return []
 
+    def get_group_members(self, group: str):
+        return self.list_group_members(group)
+
     def get_user(self, person_id: str):
         return {
             "personId": person_id,

--- a/tests/test_email_list_pipeline.py
+++ b/tests/test_email_list_pipeline.py
@@ -23,6 +23,9 @@ class FakeSimClient:
             ]
         return []
 
+    def get_group_members(self, group: str):
+        return self.list_group_members(group)
+
     def get_user(self, person_id: str):
         return {
             "personId": person_id,

--- a/tests/test_sim_client_adapter.py
+++ b/tests/test_sim_client_adapter.py
@@ -15,6 +15,20 @@ class FakeSimClient:
     def list_group_members(self, group: str):
         return []
 
+    def get_group_members(self, group: str):
+        return []
+
+    def get_user(self, person_id: str):
+        return {"id": person_id}
+
+
+class OnlyGetGroupMembersClient:
+    def list_groups(self, service: str):
+        return []
+
+    def get_group_members(self, group: str):
+        return [{"personId": "p1", "groupId": group}]
+
     def get_user(self, person_id: str):
         return {"id": person_id}
 
@@ -28,3 +42,12 @@ def test_from_default_resolves_nested_factory(monkeypatch: pytest.MonkeyPatch) -
     adapter = SIMClientAdapter.from_default()
 
     assert isinstance(adapter.client, FakeSimClient)
+
+
+def test_adapter_uses_get_group_members_when_list_missing() -> None:
+    adapter = SIMClientAdapter(client=OnlyGetGroupMembersClient())
+
+    members = adapter.list_group_members("grp")
+
+    assert members[0].group_id == "grp"
+    assert members[0].person_id == "p1"


### PR DESCRIPTION
## Summary
- update the SIM client adapter to open sim_api_wrapper.SimApiClient as a context manager and validate required methods
- support both list_group_members and get_group_members APIs while ensuring the adapter can be used in a with-statement
- ensure the CLI and tests use the new adapter lifecycle and cover the get_group_members fallback

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d9a4cca4f08325b75122e41089fa7c