### PR TITLE
Handle non-mapping SIM group payloads

### DIFF
--- a/src/sim_apps/sim_integration/clients.py
+++ b/src/sim_apps/sim_integration/clients.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import logging
 from dataclasses import dataclass
 from importlib import import_module
-from typing import Any, ClassVar, ContextManager, Iterable, Protocol
+from typing import Any, ClassVar, ContextManager, Iterable, Mapping, Protocol
 
 from .models import Group, Member, User
 
@@ -158,6 +158,12 @@ class SIMClientAdapter:
         raw_groups = self.client.list_groups(service)
         groups: list[Group] = []
         for raw in raw_groups:
+            if not isinstance(raw, Mapping):
+                LOGGER.warning(
+                    "Skipping group payload with unexpected type: %s",
+                    type(raw).__name__,
+                )
+                continue
             try:
                 groups.append(Group.from_raw(raw))
             except ValueError as exc:

--- a/tests/test_sim_client_adapter.py
+++ b/tests/test_sim_client_adapter.py
@@ -33,6 +33,20 @@ class OnlyGetGroupMembersClient:
         return {"id": person_id}
 
 
+class NonMappingGroupClient:
+    def list_groups(self, service: str):
+        return ["bad", {"id": "good", "name": "Good"}]
+
+    def list_group_members(self, group: str):
+        return []
+
+    def get_group_members(self, group: str):
+        return []
+
+    def get_user(self, person_id: str):
+        return {"id": person_id}
+
+
 def test_from_default_resolves_nested_factory(monkeypatch: pytest.MonkeyPatch) -> None:
     module = SimpleNamespace(
         Client=SimpleNamespace(factory=lambda **_: FakeSimClient())
@@ -51,3 +65,13 @@ def test_adapter_uses_get_group_members_when_list_missing() -> None:
 
     assert members[0].group_id == "grp"
     assert members[0].person_id == "p1"
+
+
+def test_adapter_skips_non_mapping_group_payloads(caplog: pytest.LogCaptureFixture) -> None:
+    adapter = SIMClientAdapter(client=NonMappingGroupClient())
+
+    with caplog.at_level("WARNING"):
+        groups = adapter.list_groups("svc")
+
+    assert [group.id for group in groups] == ["good"]
+    assert "Skipping group payload with unexpected type" in caplog.text


### PR DESCRIPTION
## Summary
- guard against non-mapping group payloads returned by the SIM client and log a warning instead of crashing
- add regression coverage for skipping malformed group data in the SIM client adapter

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d9a617c9f883259d70b4c8cf84d6e3