### PR TITLE
Update README installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,15 +11,9 @@ Utilities and command line applications built on top of the [sim-api-wrapper](ht
 
 ## Installation
 
-The project uses [uv](https://github.com/astral-sh/uv) for dependency management. Install both the wrapper and sim-apps in editable mode:
+The project uses [uv](https://github.com/astral-sh/uv) for dependency management. The SIM API wrapper is installed automatically from its GitHub repository when you set up this project, so you only need to create an environment for `sim-apps`:
 
 ```bash
-# Install the SIM API wrapper
-cd /path/to/sim-api-wrapper
-uv venv
-uv pip install -e .
-
-# Install sim-apps
 cd /path/to/sim-apps
 uv venv
 uv pip install -e .[dev]


### PR DESCRIPTION
## Summary
- clarify that the SIM API wrapper is installed automatically when setting up sim-apps
- simplify the installation steps to cover only the sim-apps virtual environment

## Testing
- not run (documentation change only)

------
https://chatgpt.com/codex/tasks/task_e_68da5f3dd508832596b89c7c8a6cf975